### PR TITLE
debian: add required libpam0g-dev dependency.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,6 +1,6 @@
 Source: pam-ssh-auth-info
 Build-Depends:
-	debhelper-compat (= 13)
+	debhelper-compat (= 13), libpam0g-dev
 Homepage: https://github.Eero.xn--Hkkinen-5wa.fi/pam-ssh-auth-info/
 Maintainer: Eero Häkkinen <Eero+pam-ssh-auth-info@xn--Hkkinen-5wa.fi>
 Priority: optional


### PR DESCRIPTION
Without that package, the build would fail with:

```
checking for pam_get_item in -lpam... no
        tail -v -n \+0 config.log
==> config.log <==
[...]
configure:8830: checking for pam_get_item in -lpam
configure:8855: gcc -o conftest -g -O2 -fdebug-prefix-map=/tmp/pam-ssh-auth-info/sources=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -Wl,-z,relro -Wl,-z,now conftest.c -lpam   >&5
/usr/bin/ld: cannot find -lpam
collect2: error: ld returned 1 exit status
```